### PR TITLE
add scale option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Compatible with OpenSeadragon 2.0.0 or greater.
 
 To use, include the `openseadragon-html-overlay.js` file after `openseadragon.js` on your web page.
 
-To add HTML overlay capability to your OpenSeadragon Viewer, call `htmlOverlay()` on it. This will return a new object with the following methods:
+To add HTML overlay capability to your OpenSeadragon Viewer, call `htmlOverlay()` or `htmlOverlay({scale: scaleWidth})` on it. Scale option is useful in case the width of tileSource is not set, or you want html overlay dimensions to be independent of image dimensions. By default scale is set to 1. This will return a new object with the following methods:
 
 * `element()`: Returns the overlay's parent HTML element that you should add all of your HTML elements to. As the user zooms and pans, the parent element will transform to match. Add your elements according to the OpenSeadragon Viewport coordinate system.
 * `onClick(element, handler)`: If you want to accept click events on a child element, use this method. It takes care of making sure the click isn't also handled by the Viewer. The handler you provide is called when the click occurs and given a single argument, an [OpenSeadragon.MouseTracker click event](http://openseadragon.github.io/docs/OpenSeadragon.MouseTracker.html#clickHandler).

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,10 @@
 OPENSEADRAGON HTML OVERLAY CHANGELOG
 ===================================
 
+0.0.2:
+
+* Scale option added
+
 0.0.1:
 
 * First version

--- a/demo.html
+++ b/demo.html
@@ -7,11 +7,19 @@
         <style type="text/css">
 
             html,
-            body,
-            .openseadragon1 {
+            body {
                 width: 100%;
                 height: 100%;
                 margin: 0;
+                float: left;
+            }
+
+            .openseadragon1,
+            .openseadragon2 {
+                width: calc(50% - 10px);
+                height: 100%;
+                margin: 5px;
+                float: left;
             }
 
             .text-overlay {
@@ -38,16 +46,48 @@
                 cursor: pointer;
             }
 
+            .text-overlay2 {
+                position: absolute;
+                left: 200px;
+                top: 65px;
+                width: 420px;
+                font-size: 25px;
+                font-family: sans-serif;
+                color: white;
+                text-shadow: 3px 3px 2px rgba(0, 0, 0, 0.5);
+            }
+
+            .text-overlay2 a {
+                color: #DDF;
+            }
+
+            .image-overlay2 {
+                position: absolute;
+                left: 650px;
+                top: 65px;
+                width: 140px;
+                height: 140px;
+                cursor: pointer;
+            }
+
         </style>
     </head>
     <body>
         <div id="contentDiv" class="openseadragon1"></div>
+        <div id="contentDiv2" class="openseadragon2"></div>
         <div class="text-overlay">
             <h1>Hello!</h1>
             <p>Lorem ipsum <a href="https://openseadragon.github.io" target="_blank">dolor sit amet</a>, consectetur adipiscing elit. Mauris faucibus nec ex et feugiat. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Nulla ut dignissim nisl.</p>
             <p>Nam aliquam sem ut est hendrerit, a lobortis risus maximus. Nam tortor magna, tristique id sem a, faucibus tincidunt sem. Nulla hendrerit tortor at semper convallis. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae.</p>
         </div>
         <img class="image-overlay" src="openseadragonlogo-transparent.png">
+        <div class="text-overlay2">
+            <h1>Hello! This overlay is using scale of 1000</h1>
+            <p>Lorem ipsum <a href="https://openseadragon.github.io" target="_blank">dolor sit amet</a>, consectetur adipiscing elit. Mauris faucibus nec ex et feugiat. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Nulla ut dignissim nisl.</p>
+            <p>Nam aliquam sem ut est hendrerit, a lobortis risus maximus. Nam tortor magna, tristique id sem a, faucibus tincidunt sem. Nulla hendrerit tortor at semper convallis. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae.</p>
+        </div>
+        <img class="image-overlay2" src="openseadragonlogo-transparent.png">
+
 
         <script>
             // ----------
@@ -84,6 +124,27 @@
                 overlay.onClick(imageOverlay, function() {
                     alert('Hello!');
                 });
+
+                var viewer2 = OpenSeadragon({
+                    id: "contentDiv2",
+                    prefixUrl: "https://cdn.jsdelivr.net/npm/openseadragon/build/openseadragon/images/",
+                    tileSources: [{
+                        tileSource: tileSource,
+
+                    }]
+                });
+
+                var overlay2 = viewer2.htmlOverlay({scale: 1000});
+
+                overlay2.element().appendChild(document.querySelector('.text-overlay2'));
+
+                var imageOverlay2 = document.querySelector('.image-overlay2');
+                overlay2.element().appendChild(imageOverlay2);
+                overlay2.onClick(imageOverlay2, function() {
+                    alert('Hello! This image has different dimensions');
+                });
+
+
             }
 
             // ----------

--- a/openseadragon-html-overlay.js
+++ b/openseadragon-html-overlay.js
@@ -1,4 +1,4 @@
-// OpenSeadragon HTML Overlay plugin 0.0.1
+// OpenSeadragon HTML Overlay plugin 0.0.2
 
 (function() {
 
@@ -12,12 +12,18 @@
     }
 
     // ----------
-    $.Viewer.prototype.htmlOverlay = function() {
+    $.Viewer.prototype.htmlOverlay = function(options) {
         if (this._htmlOverlayInfo) {
             return this._htmlOverlayInfo;
         }
 
         this._htmlOverlayInfo = new Overlay(this);
+        if (options && options.scale) {
+            this._htmlOverlayInfo._scale = options.scale; // arbitrary scale for created fabric canvas
+        }
+        else {
+            this._htmlOverlayInfo._scale = 1;
+        }
         return this._htmlOverlayInfo;
     };
 
@@ -84,7 +90,7 @@
             var rotation = this._viewer.viewport.getRotation();
 
             // TODO: Expose an accessor for _containerInnerSize in the OSD API so we don't have to use the private variable.
-            var scale = this._viewer.viewport._containerInnerSize.x * zoom;
+            var scale = this._viewer.viewport._containerInnerSize.x * zoom / this._scale;
 
             this._element.style.transform =
                 'translate(' + p.x + 'px,' + p.y + 'px) scale(' + scale + ') rotate(' + rotation + ')';

--- a/openseadragon-html-overlay.js
+++ b/openseadragon-html-overlay.js
@@ -12,14 +12,16 @@
     }
 
     // ----------
-    $.Viewer.prototype.htmlOverlay = function(options) {
+    $.Viewer.prototype.htmlOverlay = function (options) {
+        options = options || {};
+
         if (this._htmlOverlayInfo) {
             return this._htmlOverlayInfo;
         }
 
         this._htmlOverlayInfo = new Overlay(this);
-        if (options && options.scale) {
-            this._htmlOverlayInfo._scale = options.scale; // arbitrary scale for created fabric canvas
+        if (options.scale) {
+            this._htmlOverlayInfo._scale = options.scale; // arbitrary scale for created overlay element
         }
         else {
             this._htmlOverlayInfo._scale = 1;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "html-overlay",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "An OpenSeadragon plugin that adds HTML overlay capability.",
   "main": "openseadragon-html-overlay.js",
   "dependencies": {


### PR DESCRIPTION
Adds scale option. To add HTML overlay with scaling to your OpenSeadragon Viewer, call htmlOverlay({scale: scaleWidth}).
This is useful in case the width of tileSource is not set, or you want html overlay dimensions to be independent of image dimensions. By default scale is set to 1 for backwards compatibility or cases where tileSource width is set.